### PR TITLE
P tags have nbsp - proof of concept

### DIFF
--- a/templates/tinymce_script.html.twig
+++ b/templates/tinymce_script.html.twig
@@ -44,7 +44,8 @@ function OH_MEDIA_TINYMCE(container, selector) {
       quickbars_image_toolbar: false,
       license_key: 'gpl',
       max_height: 600,
-      valid_elements: validElements,
+      // valid_elements: validElements,
+      valid_elements: '#p',
     });
   });
 }


### PR DESCRIPTION
Currently when hitting Enter to make a new line, a new P tag is created. In the editor it takes up visual space in height, but once saved, the P tags in the output don't have any height. This is because TinyMCE strips out the contents of the P tag. Completely empty P tag = 0 height.

The desired outcome is for the P tags to have either a `#nbsp;` unicode or `<br>` inside to keep their height. It turns out that this is easy to do. In the `valid_elements` option of TinyMCE, `p` should be changed to `#p`. This makes it so when you save, any empty P tags get rendered with `#nbsp;` inside.

**A problem I ran into**: I tried changing this value on the correct `HtmlTags.php` file, but it didn't work. Then to test it I tried changing the file to only allow H2 tags, but it still allowed any and all tags once saved. I suspect that file is not working correctly, but I am not sure. That is why for this proof of concept I simply commented out the reference to it, and used a basic valid_elements option with only the P tags allowed for now. This should obviously be corrected.