### PR TITLE
Feature/image plugin

### DIFF
--- a/assets/js/tinymce/filebrowser.js
+++ b/assets/js/tinymce/filebrowser.js
@@ -215,7 +215,7 @@ export default function (filesUrl) {
         const linkText = selectedText ? selectedText : item.name;
 
         editor.insertContent(
-          `<a href="{{file_href(${item.id})}}" title="${item.name}" target="_blank">${linkText}</a>`
+          `<a href="${item.path}" title="${item.name}" target="_blank">${linkText}</a>`
         );
 
         dialog.close();
@@ -293,7 +293,9 @@ export default function (filesUrl) {
               row = getFolderRow(item, populateFiles.bind(null, item.url));
             } else if ('image' === item.type) {
               const onclickImage = () => {
-                editor.insertContent(`{{image(${item.id})}}`);
+                editor.insertContent(
+                  `<img src="${item.path}" width="${item.width}" height="${item.height}">`
+                );
 
                 dialog.close();
               };

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -8,7 +8,7 @@ services:
     oh_media_wysiwyg.wysiwyg: '@OHMedia\WysiwygBundle\Service\Wysiwyg'
 
     OHMedia\WysiwygBundle\Form\Type\WysiwygType:
-        arguments: ["@oh_media_wysiwyg.wysiwyg"]
+        autowire: true
         tags: ["form.type"]
 
     OHMedia\WysiwygBundle\Twig\WysiwygExtension:

--- a/src/Controller/TinyMCEController.php
+++ b/src/Controller/TinyMCEController.php
@@ -79,6 +79,7 @@ class TinyMCEController extends AbstractController
                 $item = [
                     'name' => (string) $listingItem,
                     'id' => (string) $id,
+                    'path' => $this->fileManager->getWebPath($listingItem),
                     'locked' => $listingItem->isLocked(),
                 ];
 
@@ -89,6 +90,9 @@ class TinyMCEController extends AbstractController
                         'height' => 40,
                         'style' => 'height:40px;display:block',
                     ]);
+
+                    list($item['width'], $item['height'])
+                        = $imageManager->constrainWidthAndHeight($listingItem->getWidth(), $listingItem->getHeight());
                 } else {
                     $item['type'] = 'file';
                 }

--- a/src/Form/Type/WysiwygType.php
+++ b/src/Form/Type/WysiwygType.php
@@ -67,7 +67,7 @@ class WysiwygType extends AbstractType
 
     public function replaceShortcodes(PreSetDataEvent $event): void
     {
-        $data = $event->getData();
+        $data = $event->getData() ?? '';
 
         preg_match_all('/{{file_href\(([^(]*)\)}}/', $data, $files, \PREG_SET_ORDER);
 

--- a/src/Form/Type/WysiwygType.php
+++ b/src/Form/Type/WysiwygType.php
@@ -47,7 +47,7 @@ class WysiwygType extends AbstractType
 
         $builder->addEventListener(
             FormEvents::PRE_SET_DATA,
-            [$this, 'onPreSetData']
+            [$this, 'replaceShortcodes']
         );
 
         $builder->addEventListener(
@@ -72,10 +72,11 @@ class WysiwygType extends AbstractType
         );
     }
 
-    public function onPreSetData(PreSetDataEvent $event): void
+    public function replaceShortcodes(PreSetDataEvent $event): void
     {
         $data = $event->getData();
 
+        // TODO: do we actually need to do this?
         preg_match_all('/{{file_href\(([^(]*)\)}}/', $data, $files, \PREG_SET_ORDER);
 
         foreach ($files as $file) {

--- a/src/Form/Type/WysiwygType.php
+++ b/src/Form/Type/WysiwygType.php
@@ -126,7 +126,7 @@ class WysiwygType extends AbstractType
 
     private function restoreShortcodes(string $data): string
     {
-        preg_match_all('/<img[^>]*>/', $data, $images);
+        preg_match_all('/<img[^>]*>/', $data, $images, \PREG_SET_ORDER);
 
         foreach ($images as $image) {
             preg_match('/src="\/f\/([^\/]*)\/[^"]*"/', $image[0], $src);

--- a/src/Form/Type/WysiwygType.php
+++ b/src/Form/Type/WysiwygType.php
@@ -102,17 +102,20 @@ class WysiwygType extends AbstractType
 
             if ($image) {
                 $src = $this->fileManager->getWebPath($image);
-                $img = '<img src="'.$src.'"';
+
+                $attributes = [
+                    'src="'.$src.'"',
+                ];
 
                 if ($width) {
-                    $img .= ' width="'.$width.'"';
+                    $attributes[] = 'width="'.$width.'"';
                 }
 
                 if ($height) {
-                    $img .= ' height="'.$height.'"';
+                    $attributes[] = 'height="'.$height.'"';
                 }
 
-                $img .= '>';
+                $img = '<img '.implode(' ', $attributes).'>';
 
                 $data = str_replace($shortcode, $img, $data);
             }

--- a/src/Form/Type/WysiwygType.php
+++ b/src/Form/Type/WysiwygType.php
@@ -162,6 +162,23 @@ class WysiwygType extends AbstractType
             $data = str_replace($image[0], $shortcode, $data);
         }
 
+        // find any remaining file URLs
+        preg_match_all('/href="(\/f\/([^\/]*)\/[^"]*)"/', $data, $files, \PREG_SET_ORDER);
+
+        foreach ($files as $f) {
+            $token = $f[2];
+
+            $file = $this->fileRepository->findOneByToken($token);
+
+            if (!$file) {
+                continue;
+            }
+
+            $shortcode = '{{file_href('.$file->getId().')}}';
+
+            $data = str_replace($f[1], $shortcode, $data);
+        }
+
         return $data;
     }
 

--- a/src/OHMediaWysiwygBundle.php
+++ b/src/OHMediaWysiwygBundle.php
@@ -64,6 +64,7 @@ class OHMediaWysiwygBundle extends AbstractBundle
             'charmap',
             'code',
             'directionality',
+            'image',
             'link',
             'lists',
             'table',
@@ -119,7 +120,7 @@ class OHMediaWysiwygBundle extends AbstractBundle
 
         $toolbar = [
             'undo redo',
-            'blocks ohshortcodes ohfilebrowser ohcontentlinks',
+            'blocks ohshortcodes image ohfilebrowser ohcontentlinks',
             'bold italic underline numlist bullist',
             'alignleft aligncenter alignright alignjustify',
             'outdent indent',

--- a/src/Service/Wysiwyg.php
+++ b/src/Service/Wysiwyg.php
@@ -237,9 +237,11 @@ class Wysiwyg
                     // string surrounded by double-quotes
                     // give back a string escaped and surrounded by double-quotes
                     $arg = $dq.addslashes(trim($arg, $dq)).$dq;
+                } elseif ('null' === $arg) {
+                    // leave it
                 } else {
                     // not a string - force int
-                    $arg = intval($arg);
+                    $arg = abs(intval($arg));
                 }
 
                 $args[$i] = $arg;

--- a/src/Service/Wysiwyg.php
+++ b/src/Service/Wysiwyg.php
@@ -91,6 +91,18 @@ class Wysiwyg
                 ->getQuery()
                 ->getResult();
 
+            // determine if we need to search for {{image(ID, ...)}}
+            preg_match('/{{image\((\d+)\)}}/', $shortcode, $matches);
+
+            if ($matches) {
+                $otherShortcode = '{{image('.$matches[1].',%)}}';
+                $otherEntities = $repository->getShortcodeQueryBuilder($otherShortcode)
+                    ->getQuery()
+                    ->getResult();
+
+                $entities = array_merge($entities, $otherEntities);
+            }
+
             $links = [];
 
             foreach ($entities as $entity) {
@@ -101,7 +113,7 @@ class Wysiwyg
 
                 $text = $repository->getShortcodeLinkText($entity);
 
-                $links[] = [
+                $links[$entity->getId()] = [
                     'href' => $href,
                     'text' => $text,
                 ];
@@ -117,7 +129,7 @@ class Wysiwyg
                     ];
                 }
 
-                $placements[$heading]['links'] += $links;
+                $placements[$heading]['links'] += array_values($links);
             }
         }
 

--- a/templates/tinymce_script.html.twig
+++ b/templates/tinymce_script.html.twig
@@ -42,6 +42,7 @@ function OH_MEDIA_TINYMCE(container, selector) {
       toolbar: OH_MEDIA_TINYMCE_TOOLBAR,
       toolbar_mode: 'wrap',
       image_list: '{{ path('tinymce_image_list') }}',
+      image_caption: true,
       block_formats: [
           'Paragraph=p',
           'Heading 2=h2',

--- a/templates/tinymce_script.html.twig
+++ b/templates/tinymce_script.html.twig
@@ -43,6 +43,7 @@ function OH_MEDIA_TINYMCE(container, selector) {
       toolbar_mode: 'wrap',
       image_list: '{{ path('tinymce_image_list') }}',
       image_caption: true,
+      image_description: false,
       block_formats: [
           'Paragraph=p',
           'Heading 2=h2',

--- a/templates/tinymce_script.html.twig
+++ b/templates/tinymce_script.html.twig
@@ -41,6 +41,7 @@ function OH_MEDIA_TINYMCE(container, selector) {
       menu: OH_MEDIA_TINYMCE_MENU,
       toolbar: OH_MEDIA_TINYMCE_TOOLBAR,
       toolbar_mode: 'wrap',
+      image_list: '{{ path('tinymce_image_list') }}',
       block_formats: [
           'Paragraph=p',
           'Heading 2=h2',


### PR DESCRIPTION
Testing out the Image plugin.

Updating the editor workflow so that `file_href` and `image` shortcodes aren't actually seen by the user. Instead they actually get to see images. Before the WysiwygType field is populated, these shortcodes get stripped out, and before it is submitted, they get replaced. This keeps the shortcodes in the DB so that existing functionality keeps working. There is an added benefit in that if a user decides to manually use a file path, it will get replaced by the shortcode.